### PR TITLE
댓글 기능 

### DIFF
--- a/src/main/java/com/hh/mirishop/comment/controller/CommentController.java
+++ b/src/main/java/com/hh/mirishop/comment/controller/CommentController.java
@@ -1,0 +1,48 @@
+package com.hh.mirishop.comment.controller;
+
+import com.hh.mirishop.auth.domain.UserDetailsImpl;
+import com.hh.mirishop.comment.dto.CommentRequest;
+import com.hh.mirishop.comment.service.CommentService;
+import com.hh.mirishop.common.dto.BaseResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/v1/posts/{postId}/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<Void>> createComment(@Valid @RequestBody CommentRequest commentRequest,
+                                                            @PathVariable("postId") Long postId,
+                                                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        Long commentId = commentService.createComment(commentRequest, userDetails.getNumber(), postId);
+
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{commentId}")
+                .buildAndExpand(commentId)
+                .toUri();
+
+        return ResponseEntity.created(location).body(BaseResponse.of("댓글이 생성되었습니다.", true, null));
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<BaseResponse<Void>> deleteComment(@PathVariable("commentId") Long commentId,
+                                                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        commentService.deleteComment(commentId, userDetails.getNumber());
+        return ResponseEntity.ok(BaseResponse.of("댓글이 삭제되었습니다.", true, null));
+    }
+}

--- a/src/main/java/com/hh/mirishop/comment/controller/CommentController.java
+++ b/src/main/java/com/hh/mirishop/comment/controller/CommentController.java
@@ -25,11 +25,14 @@ public class CommentController {
 
     private final CommentService commentService;
 
+    /*
+    댓글 작성
+    */
     @PostMapping
     public ResponseEntity<BaseResponse<Void>> createComment(@Valid @RequestBody CommentRequest commentRequest,
                                                             @PathVariable("postId") Long postId,
                                                             @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        Long commentId = commentService.createComment(commentRequest, userDetails.getNumber(), postId);
+        Long commentId = commentService.createCommentOrReply(commentRequest, userDetails.getNumber(), postId);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{commentId}")
@@ -39,10 +42,30 @@ public class CommentController {
         return ResponseEntity.created(location).body(BaseResponse.of("댓글이 생성되었습니다.", true, null));
     }
 
+    /*
+    댓글 삭제(대댓글도 가능)
+    */
     @DeleteMapping("/{commentId}")
     public ResponseEntity<BaseResponse<Void>> deleteComment(@PathVariable("commentId") Long commentId,
                                                             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         commentService.deleteComment(commentId, userDetails.getNumber());
         return ResponseEntity.ok(BaseResponse.of("댓글이 삭제되었습니다.", true, null));
+    }
+
+    /*
+    대댓글 작성
+    */
+    @PostMapping("/reply")
+    public ResponseEntity<BaseResponse<Void>> createReply(@Valid @RequestBody CommentRequest commentRequest,
+                                                          @PathVariable("postId") Long postId,
+                                                          @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        Long commentId = commentService.createCommentOrReply(commentRequest, userDetails.getNumber(), postId);
+
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{commentId}")
+                .buildAndExpand(commentId)
+                .toUri();
+
+        return ResponseEntity.created(location).body(BaseResponse.of("대댓글이 생성되었습니다.", true, null));
     }
 }

--- a/src/main/java/com/hh/mirishop/comment/dto/CommentRequest.java
+++ b/src/main/java/com/hh/mirishop/comment/dto/CommentRequest.java
@@ -1,5 +1,6 @@
 package com.hh.mirishop.comment.dto;
 
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,6 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CommentRequest {
 
+    @Size(min = 1, max = 400, message = "400자 이하로 입력해주세요.")
     private String content;
     private Long parentCommentId;
 }

--- a/src/main/java/com/hh/mirishop/comment/dto/CommentRequest.java
+++ b/src/main/java/com/hh/mirishop/comment/dto/CommentRequest.java
@@ -1,0 +1,12 @@
+package com.hh.mirishop.comment.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentRequest {
+
+    private String content;
+    private Long parentCommentId;
+}

--- a/src/main/java/com/hh/mirishop/comment/dto/CommentResponse.java
+++ b/src/main/java/com/hh/mirishop/comment/dto/CommentResponse.java
@@ -1,0 +1,18 @@
+package com.hh.mirishop.comment.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class CommentResponse {
+
+    private String nickName;
+    private String content;
+    private Long commentId;
+    private Long parentCommentId;
+    private int likeCount;
+}

--- a/src/main/java/com/hh/mirishop/comment/entity/Comment.java
+++ b/src/main/java/com/hh/mirishop/comment/entity/Comment.java
@@ -1,0 +1,65 @@
+package com.hh.mirishop.comment.entity;
+
+import com.hh.mirishop.member.entity.Member;
+import com.hh.mirishop.post.entity.Post;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "Comments")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long commentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_number", nullable = false)
+    private Member member;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parentComment;
+
+    @Column(name = "created_at", nullable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted;
+
+    // 게시글 삭제(soft delete방식)
+    public void delete(boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+}

--- a/src/main/java/com/hh/mirishop/comment/repository/CommentRepository.java
+++ b/src/main/java/com/hh/mirishop/comment/repository/CommentRepository.java
@@ -1,0 +1,17 @@
+package com.hh.mirishop.comment.repository;
+
+import com.hh.mirishop.comment.entity.Comment;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("SELECT c FROM Comment c WHERE c.post.id = :postId")
+    List<Comment> findByPostId(@Param("postId") Long postId);
+
+    @Query("SELECT c FROM Comment c WHERE c.parentComment.id = :parentCommentId")
+    List<Comment> findByParentCommentId(@Param("ParentCommentId") Long parentCommentId);
+}

--- a/src/main/java/com/hh/mirishop/comment/service/CommentService.java
+++ b/src/main/java/com/hh/mirishop/comment/service/CommentService.java
@@ -1,13 +1,10 @@
 package com.hh.mirishop.comment.service;
 
 import com.hh.mirishop.comment.dto.CommentRequest;
-import com.hh.mirishop.post.entity.Post;
 
 public interface CommentService {
 
-    Long createComment(CommentRequest request, Long memberNumber, Long postId);
-
-    Post findPostById(Long postId);
+    Long createCommentOrReply(CommentRequest request, Long memberNumber, Long postId);
 
     void deleteComment(Long commentId, Long memberNumber);
 }

--- a/src/main/java/com/hh/mirishop/comment/service/CommentService.java
+++ b/src/main/java/com/hh/mirishop/comment/service/CommentService.java
@@ -1,0 +1,14 @@
+package com.hh.mirishop.comment.service;
+
+import com.hh.mirishop.comment.dto.CommentRequest;
+import com.hh.mirishop.post.entity.Post;
+
+public interface CommentService {
+
+    Long createComment(CommentRequest request, Long memberNumber, Long postId);
+
+    Post findPostById(Long postId);
+
+    void deleteComment(Long commentId, Long memberNumber);
+}
+

--- a/src/main/java/com/hh/mirishop/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/hh/mirishop/comment/service/CommentServiceImpl.java
@@ -1,0 +1,85 @@
+package com.hh.mirishop.comment.service;
+
+
+import com.hh.mirishop.comment.dto.CommentRequest;
+import com.hh.mirishop.comment.entity.Comment;
+import com.hh.mirishop.comment.repository.CommentRepository;
+import com.hh.mirishop.common.exception.CommentException;
+import com.hh.mirishop.common.exception.ErrorCode;
+import com.hh.mirishop.common.exception.MemberException;
+import com.hh.mirishop.common.exception.PostException;
+import com.hh.mirishop.member.entity.Member;
+import com.hh.mirishop.member.repository.MemberRepository;
+import com.hh.mirishop.post.entity.Post;
+import com.hh.mirishop.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public Long createComment(CommentRequest request, Long memberNumber, Long postId) {
+        Post post = findPostById(postId);
+        Member member = memberRepository.findById(memberNumber)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+        Long parentCommentId = request.getParentCommentId();
+        if (parentCommentId != null) {
+            Comment parentComment = commentRepository.findById(parentCommentId)
+                    .orElseThrow(() -> new CommentException(ErrorCode.PARENT_COMMENT_NOT_FOUND));
+
+            if (parentComment.getParentComment() != null) {
+                throw new CommentException(ErrorCode.SUBCOMMENT_NOT_ALLOWED);
+            }
+        }
+        Comment comment = Comment.builder()
+                .post(post)
+                .content(request.getContent())
+                .member(member)
+                .isDeleted(false)
+                .build();
+
+        commentRepository.save(comment);
+        /*
+        뉴스피드에 대한 로직 고려
+        */
+        return comment.getCommentId();
+    }
+
+    @Override
+    public Post findPostById(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+    }
+
+    public List<Comment> getCommentsByPostId(Long postId) {
+        return commentRepository.findByPostId(postId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteComment(Long commentId, Long currentMemberNumber) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
+
+        checkAuthorizedMember(currentMemberNumber, comment);
+
+        comment.delete(true);
+        commentRepository.save(comment);
+    }
+
+    private void checkAuthorizedMember(Long currentMemberNumber, Comment comment) {
+        if (!comment.getMember().getNumber().equals(currentMemberNumber)) {
+            throw new CommentException(ErrorCode.UNAUTHORIZED_COMMENT_ACCESS);
+        }
+    }
+}

--- a/src/main/java/com/hh/mirishop/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/hh/mirishop/comment/service/CommentServiceImpl.java
@@ -7,6 +7,8 @@ import com.hh.mirishop.common.exception.CommentException;
 import com.hh.mirishop.common.exception.ErrorCode;
 import com.hh.mirishop.common.exception.MemberException;
 import com.hh.mirishop.common.exception.PostException;
+import com.hh.mirishop.like.domain.LikeType;
+import com.hh.mirishop.like.repository.LikeRepository;
 import com.hh.mirishop.member.entity.Member;
 import com.hh.mirishop.member.repository.MemberRepository;
 import com.hh.mirishop.post.entity.Post;
@@ -24,6 +26,7 @@ public class CommentServiceImpl implements CommentService {
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
     private final MemberRepository memberRepository;
+    private final LikeRepository likeRepository;
 
     @Override
     @Transactional
@@ -66,6 +69,11 @@ public class CommentServiceImpl implements CommentService {
 
         comment.delete(true);
         commentRepository.save(comment);
+    }
+
+    @Transactional
+    public Integer countLikeForComment(Long commentId) {
+        return likeRepository.countByItemIdAndLikeType(commentId, LikeType.COMMENT);
     }
 
     private Post findPostById(Long postId) {

--- a/src/main/java/com/hh/mirishop/common/exception/CommentException.java
+++ b/src/main/java/com/hh/mirishop/common/exception/CommentException.java
@@ -1,0 +1,15 @@
+package com.hh.mirishop.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CommentException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final String message;
+
+    public CommentException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/main/java/com/hh/mirishop/common/exception/ErrorCode.java
+++ b/src/main/java/com/hh/mirishop/common/exception/ErrorCode.java
@@ -44,7 +44,7 @@ public enum ErrorCode {
     // COMMENT 에러 관련
     COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "댓글이 존재하지 않습니다."),
     PARENT_COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "상위 댓글이 없습니다."),
-    SUBCOMMENT_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "대댓글에 대한 추가 댓글은 불가능합니다."),
+    SUBCOMMENT_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "대댓글을 달 수 없습니다."),
     UNAUTHORIZED_COMMENT_ACCESS(HttpStatus.UNAUTHORIZED, "댓글 삭제는 회원 본인만 가능합니다."),
     ;
 

--- a/src/main/java/com/hh/mirishop/common/exception/ErrorCode.java
+++ b/src/main/java/com/hh/mirishop/common/exception/ErrorCode.java
@@ -34,12 +34,18 @@ public enum ErrorCode {
 
     // post 에러 관련
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다."),
-    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "게시글 수정/삭제는 회원 본인만 가능합니다."),
+    UNAUTHORIZED_POST_ACCESS(HttpStatus.UNAUTHORIZED, "게시글 수정/삭제는 회원 본인만 가능합니다."),
 
     // LIKE 에러 관련
     ALREADY_LIKE(HttpStatus.CONFLICT,"이미 좋아요를 누른 게시물입니다."),
     CORRESPOND_LIKE_TYPE(HttpStatus.BAD_REQUEST, "올바른 데이터 타입이 아닙니다."),
     NOT_LIKE(HttpStatus.CONFLICT, "좋아요를 누르지 않았습니다."),
+
+    // COMMENT 에러 관련
+    COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "댓글이 존재하지 않습니다."),
+    PARENT_COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "상위 댓글이 없습니다."),
+    SUBCOMMENT_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "대댓글에 대한 추가 댓글은 불가능합니다."),
+    UNAUTHORIZED_COMMENT_ACCESS(HttpStatus.UNAUTHORIZED, "댓글 삭제는 회원 본인만 가능합니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/hh/mirishop/common/exception/ExceptionManager.java
+++ b/src/main/java/com/hh/mirishop/common/exception/ExceptionManager.java
@@ -44,6 +44,12 @@ public class ExceptionManager extends ResponseEntityExceptionHandler {
         return handleExceptionInternal(errorCode);
     }
 
+    @ExceptionHandler(CommentException.class)
+    protected ResponseEntity<?> handleLCommentException(CommentException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return handleExceptionInternal(errorCode);
+    }
+
     private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
         return ResponseEntity.status(errorCode.getHttpStatus())
                 .body(makeErrorResponse(errorCode));

--- a/src/main/java/com/hh/mirishop/like/controller/LikeController.java
+++ b/src/main/java/com/hh/mirishop/like/controller/LikeController.java
@@ -2,7 +2,7 @@ package com.hh.mirishop.like.controller;
 
 import com.hh.mirishop.auth.domain.UserDetailsImpl;
 import com.hh.mirishop.common.dto.BaseResponse;
-import com.hh.mirishop.like.service.LikeService;
+import com.hh.mirishop.like.service.LikeServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/likes")
 public class LikeController {
 
-    private final LikeService likeService;
+    private final LikeServiceImpl likeService;
 
     @PostMapping("/posts/{postId}")
     public ResponseEntity<BaseResponse<Void>> likePost(@PathVariable("postId") Long postId,

--- a/src/main/java/com/hh/mirishop/like/controller/LikeController.java
+++ b/src/main/java/com/hh/mirishop/like/controller/LikeController.java
@@ -14,23 +14,36 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/posts/{postId}")
+@RequestMapping("/api/v1/likes")
 public class LikeController {
 
     private final LikeService likeService;
 
-    @PostMapping("/likes")
+    @PostMapping("/posts/{postId}")
     public ResponseEntity<BaseResponse<Void>> likePost(@PathVariable("postId") Long postId,
                                                        @AuthenticationPrincipal UserDetailsImpl userDetails) {
         likeService.likePost(postId, userDetails.getNumber());
-        return ResponseEntity.ok(BaseResponse.of("좋아요가 완료 되었습니다.", true, null));
+        return ResponseEntity.ok(BaseResponse.of("글 좋아요가 완료 되었습니다.", true, null));
     }
 
-
-    @DeleteMapping("/likes")
+    @DeleteMapping("/posts/{postId}")
     public ResponseEntity<BaseResponse<Void>> unlikePost(@PathVariable("postId") Long postId,
                                                          @AuthenticationPrincipal UserDetailsImpl userDetails) {
         likeService.unlikePost(postId, userDetails.getNumber());
-        return ResponseEntity.ok(BaseResponse.of("좋아요 취소가 완료 되었습니다.", true, null));
+        return ResponseEntity.ok(BaseResponse.of("글 좋아요 취소가 완료 되었습니다.", true, null));
+    }
+
+    @PostMapping("/comments/{commentId}")
+    public ResponseEntity<BaseResponse<Void>> likeComment(@PathVariable("commentId") Long commentId,
+                                                       @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        likeService.likeComment(commentId, userDetails.getNumber());
+        return ResponseEntity.ok(BaseResponse.of("댓글 좋아요가 완료 되었습니다.", true, null));
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<BaseResponse<Void>> unlikeComment(@PathVariable("commentId") Long commentId,
+                                                         @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        likeService.unlikeComment(commentId, userDetails.getNumber());
+        return ResponseEntity.ok(BaseResponse.of("댓글 좋아요 취소가 완료 되었습니다.", true, null));
     }
 }

--- a/src/main/java/com/hh/mirishop/like/entity/Like.java
+++ b/src/main/java/com/hh/mirishop/like/entity/Like.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -17,7 +18,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -34,7 +34,7 @@ public class Like {
     @Column(name = "like_id")
     private Long likeId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_number", referencedColumnName = "number")
     private Member member;
 
@@ -48,10 +48,6 @@ public class Like {
     @Column(name = "created_at")
     @CreatedDate
     private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
 
     public Like(Member member, Long itemId, LikeType likeType) {
         this.member = member;

--- a/src/main/java/com/hh/mirishop/like/repository/LikeRepository.java
+++ b/src/main/java/com/hh/mirishop/like/repository/LikeRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -16,8 +15,8 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
     // N+1 문제 해결을 위한 Fetch Join 사용
     // Fetch Join을 사용하여 특정 아이템 타입과 관련된 모든 좋아요 조회
-    @Query("SELECT l FROM Like l JOIN FETCH l.member WHERE l.itemId = :itemId AND l.likeType = :likeType")
-    List<Like> findAllByItemIdAndLikeTypeWithFetchJoin(@Param("itemId") Long itemId, @Param("likeType") LikeType likeType);
+    @Query("SELECT COUNT(l) FROM Like l WHERE l.itemId = :itemId AND l.likeType = :likeType")
+    Integer countByItemIdAndLikeType(@Param("itemId") Long itemId, @Param("likeType") LikeType likeType);
 
 
     // itemId(post 또는 comment)에서 member가 좋아요를 했는지 확인하는 메소드

--- a/src/main/java/com/hh/mirishop/like/service/LikeService.java
+++ b/src/main/java/com/hh/mirishop/like/service/LikeService.java
@@ -1,109 +1,12 @@
 package com.hh.mirishop.like.service;
 
-import com.hh.mirishop.comment.entity.Comment;
-import com.hh.mirishop.comment.repository.CommentRepository;
-import com.hh.mirishop.common.exception.CommentException;
-import com.hh.mirishop.common.exception.ErrorCode;
-import com.hh.mirishop.common.exception.LikeException;
-import com.hh.mirishop.common.exception.MemberException;
-import com.hh.mirishop.common.exception.PostException;
-import com.hh.mirishop.like.domain.LikeType;
-import com.hh.mirishop.like.entity.Like;
-import com.hh.mirishop.like.repository.LikeRepository;
-import com.hh.mirishop.member.entity.Member;
-import com.hh.mirishop.member.repository.MemberRepository;
-import com.hh.mirishop.post.entity.Post;
-import com.hh.mirishop.post.repository.PostRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+public interface LikeService {
 
-import java.util.Optional;
+    void likePost(Long postId, Long currentMemberNumber);
 
-@Service
-@RequiredArgsConstructor
-public class LikeService {
+    void unlikePost(Long postId, Long currentMemberNumber);
 
-    private final CommentRepository commentRepository;
-    private final LikeRepository likeRepository;
-    private final MemberRepository memberRepository;
-    private final PostRepository postRepository;
+    void likeComment(Long commentId, Long currentMemberNumber);
 
-    @Transactional
-    public void likePost(Long postId, Long currentMemberNumber) {
-        Member currentMember = findMember(currentMemberNumber);
-        Post post = findPost(postId);
-
-        if (isAlreadyPostLiked(postId, currentMember)) {
-            throw new LikeException(ErrorCode.ALREADY_LIKE);
-        }
-        likeRepository.save(new Like(currentMember, postId, LikeType.POST));
-
-        /*
-        뉴스피드에 대한 로직 추가
-        */
-    }
-
-    private Member findMember(Long currentMemberNumber) {
-        return memberRepository.findById(currentMemberNumber)
-                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
-    }
-
-    private Post findPost(Long postId) {
-        return postRepository.findById(postId)
-                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
-    }
-
-    private boolean isAlreadyPostLiked(Long postId, Member currentMember) {
-        return likeRepository.existsByItemIdAndLikeTypeAndMember(postId, LikeType.POST, currentMember);
-    }
-
-    @Transactional
-    public void unlikePost(Long postId, Long currentMemberNumber) {
-        Member currentMember = findMember(currentMemberNumber);
-        Post post = findPost(postId);
-        Optional<Like> likeOpt = likeRepository.findByItemIdAndLikeTypeAndMember(postId, LikeType.POST, currentMember);
-
-        if (likeOpt.isEmpty()) {
-            throw new LikeException(ErrorCode.NOT_LIKE);
-        }
-        likeRepository.delete(likeOpt.get());
-    }
-
-    @Transactional
-    public void likeComment(Long commentId, Long currentMemberNumber) {
-        Member currentMember = findMember(currentMemberNumber);
-        Comment comment = findComment(commentId);
-
-        if (isAlreadyCommentLiked(commentId, currentMember)) {
-            throw new LikeException(ErrorCode.ALREADY_LIKE);
-        }
-        likeRepository.save(new Like(currentMember, commentId, LikeType.COMMENT));
-
-        /*
-        뉴스피드에 대한 로직 추가
-        */
-    }
-
-    private Comment findComment(Long commentId) {
-        return commentRepository.findById(commentId)
-                .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
-    }
-
-    private boolean isAlreadyCommentLiked(Long commentId, Member currentMember) {
-        return likeRepository.existsByItemIdAndLikeTypeAndMember(commentId, LikeType.COMMENT, currentMember);
-    }
-
-    @Transactional
-    public void unlikeComment(Long commentId, Long currentMemberNumber) {
-        Member currentMember = findMember(currentMemberNumber);
-        Comment comment = findComment(commentId);
-        Optional<Like> likeOpt = likeRepository.findByItemIdAndLikeTypeAndMember(commentId, LikeType.COMMENT, currentMember);
-
-        if (likeOpt.isEmpty()) {
-            throw new LikeException(ErrorCode.NOT_LIKE);
-        }
-        likeRepository.delete(likeOpt.get());
-    }
-
+    void unlikeComment(Long commentId, Long currentMemberNumber);
 }

--- a/src/main/java/com/hh/mirishop/like/service/LikeServiceImpl.java
+++ b/src/main/java/com/hh/mirishop/like/service/LikeServiceImpl.java
@@ -1,0 +1,112 @@
+package com.hh.mirishop.like.service;
+
+import com.hh.mirishop.comment.entity.Comment;
+import com.hh.mirishop.comment.repository.CommentRepository;
+import com.hh.mirishop.common.exception.CommentException;
+import com.hh.mirishop.common.exception.ErrorCode;
+import com.hh.mirishop.common.exception.LikeException;
+import com.hh.mirishop.common.exception.MemberException;
+import com.hh.mirishop.common.exception.PostException;
+import com.hh.mirishop.like.domain.LikeType;
+import com.hh.mirishop.like.entity.Like;
+import com.hh.mirishop.like.repository.LikeRepository;
+import com.hh.mirishop.member.entity.Member;
+import com.hh.mirishop.member.repository.MemberRepository;
+import com.hh.mirishop.post.entity.Post;
+import com.hh.mirishop.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LikeServiceImpl implements LikeService {
+
+    private final CommentRepository commentRepository;
+    private final LikeRepository likeRepository;
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+
+    @Override
+    @Transactional
+    public void likePost(Long postId, Long currentMemberNumber) {
+        Member currentMember = findMember(currentMemberNumber);
+        Post post = findPost(postId);
+
+        if (isAlreadyPostLiked(postId, currentMember)) {
+            throw new LikeException(ErrorCode.ALREADY_LIKE);
+        }
+        likeRepository.save(new Like(currentMember, postId, LikeType.POST));
+
+        /*
+        뉴스피드에 대한 로직 추가
+        */
+    }
+
+    @Override
+    @Transactional
+    public void unlikePost(Long postId, Long currentMemberNumber) {
+        Member currentMember = findMember(currentMemberNumber);
+        Post post = findPost(postId);
+        Optional<Like> likeOpt = likeRepository.findByItemIdAndLikeTypeAndMember(postId, LikeType.POST, currentMember);
+
+        if (likeOpt.isEmpty()) {
+            throw new LikeException(ErrorCode.NOT_LIKE);
+        }
+        likeRepository.delete(likeOpt.get());
+    }
+
+    @Override
+    @Transactional
+    public void likeComment(Long commentId, Long currentMemberNumber) {
+        Member currentMember = findMember(currentMemberNumber);
+        Comment comment = findComment(commentId);
+
+        if (isAlreadyCommentLiked(commentId, currentMember)) {
+            throw new LikeException(ErrorCode.ALREADY_LIKE);
+        }
+        likeRepository.save(new Like(currentMember, commentId, LikeType.COMMENT));
+
+        /*
+        뉴스피드에 대한 로직 추가
+        */
+    }
+
+    @Override
+    @Transactional
+    public void unlikeComment(Long commentId, Long currentMemberNumber) {
+        Member currentMember = findMember(currentMemberNumber);
+        Comment comment = findComment(commentId);
+        Optional<Like> likeOpt = likeRepository.findByItemIdAndLikeTypeAndMember(commentId, LikeType.COMMENT, currentMember);
+
+        if (likeOpt.isEmpty()) {
+            throw new LikeException(ErrorCode.NOT_LIKE);
+        }
+        likeRepository.delete(likeOpt.get());
+    }
+
+    private Member findMember(Long currentMemberNumber) {
+        return memberRepository.findById(currentMemberNumber)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private Post findPost(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+    }
+
+    private boolean isAlreadyPostLiked(Long postId, Member currentMember) {
+        return likeRepository.existsByItemIdAndLikeTypeAndMember(postId, LikeType.POST, currentMember);
+    }
+
+    private Comment findComment(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
+    }
+
+    private boolean isAlreadyCommentLiked(Long commentId, Member currentMember) {
+        return likeRepository.existsByItemIdAndLikeTypeAndMember(commentId, LikeType.COMMENT, currentMember);
+    }
+}

--- a/src/main/java/com/hh/mirishop/post/controller/PostController.java
+++ b/src/main/java/com/hh/mirishop/post/controller/PostController.java
@@ -54,14 +54,25 @@ public class PostController {
     public ResponseEntity<BaseResponse<Page<PostResponse>>> getAllPosts(@RequestParam("page") int page,
                                                                         @RequestParam("size") int size,
                                                                         @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        Page<PostResponse> postList = postService.getAllposts(page - 1, size, userDetails);
+        Page<PostResponse> postList = postService.getAllpostsByMember(page - 1, size, userDetails);
 
         return new ResponseEntity<>(BaseResponse.of("게시글 목록 조회 성공", true, postList), HttpStatus.OK);
     }
 
     /*
-    비회원이 게시글 모음을 볼지, 뉴스피드를 볼지 고민해야함.
+    게시글 한개 보기
     */
+    @GetMapping("/{postId}")
+    public ResponseEntity<BaseResponse<PostResponse>> getPost(@PathVariable Long postId){
+        PostResponse postResponse = postService.getPost(postId);
+        return ResponseEntity.ok(BaseResponse.of("게시글 내용 조회 성공", true, postResponse));
+    }
+
+    /*
+    Todo : 비회원이 게시글 모음을 볼지, 뉴스피드를 볼지 고민해야함.
+    */
+
+
 
     /*
     게시글 수정

--- a/src/main/java/com/hh/mirishop/post/dto/PostResponse.java
+++ b/src/main/java/com/hh/mirishop/post/dto/PostResponse.java
@@ -19,12 +19,12 @@ public class PostResponse {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public PostResponse(Post post) {
+    public PostResponse(Post post, int likesCount) {
         this.postId = post.getPostId();
         this.title = post.getTitle();
         this.content = post.getContent();
         this.nickName = post.getMember().getNickname();
-        this.likesCount = 0;
+        this.likesCount = likesCount;
         this.createdAt = post.getCreatedAt();
         this.updatedAt = post.getUpdatedAt();
     }

--- a/src/main/java/com/hh/mirishop/post/repository/PostRepository.java
+++ b/src/main/java/com/hh/mirishop/post/repository/PostRepository.java
@@ -11,6 +11,6 @@ import java.util.Optional;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    Page<Post> findByPostIdAndIsDeletedFalse(Long postId, Pageable pageable);
+    Page<Post> findByMemberNumberAndIsDeletedFalse(Long memberNumber, Pageable pageable);
     Optional<Post> findByPostIdAndIsDeletedFalse(Long postId);
 }

--- a/src/main/java/com/hh/mirishop/post/service/PostService.java
+++ b/src/main/java/com/hh/mirishop/post/service/PostService.java
@@ -74,7 +74,7 @@ public class PostService {
 
     private void checkAuthorizedMember(Long currentMemberNumber, Post post) {
         if (!post.getMember().getNumber().equals(currentMemberNumber)) {
-            throw new PostException(ErrorCode.UNAUTHORIZED_ACCESS);
+            throw new PostException(ErrorCode.UNAUTHORIZED_POST_ACCESS);
         }
     }
 }

--- a/src/main/java/com/hh/mirishop/post/service/PostService.java
+++ b/src/main/java/com/hh/mirishop/post/service/PostService.java
@@ -5,6 +5,8 @@ import com.hh.mirishop.common.exception.ErrorCode;
 import com.hh.mirishop.common.exception.MemberException;
 import com.hh.mirishop.common.exception.PostException;
 import com.hh.mirishop.follow.repository.FollowRepository;
+import com.hh.mirishop.like.domain.LikeType;
+import com.hh.mirishop.like.repository.LikeRepository;
 import com.hh.mirishop.member.entity.Member;
 import com.hh.mirishop.member.repository.MemberRepository;
 import com.hh.mirishop.post.dto.PostRequest;
@@ -26,6 +28,7 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
+    private final LikeRepository likeRepository;
     private final FollowRepository followRepository;
 
     @Transactional
@@ -40,20 +43,32 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PostResponse> getAllposts(@RequestParam("page") int page,
+    public Page<PostResponse> getAllpostsByMember(@RequestParam("page") int page,
                                           @RequestParam("size") int size,
                                           UserDetailsImpl userDetails) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
         Long currentMemberNumber = userDetails.getNumber(); // 현재 사용자 ID 추출
+        Page<Post> posts = postRepository.findByMemberNumberAndIsDeletedFalse(currentMemberNumber, pageable);
 
-        return postRepository.findByPostIdAndIsDeletedFalse(currentMemberNumber, pageable)
-                .map(PostResponse::new);
+        return posts.map(post -> {
+            int likeCounts = likeRepository.countByItemIdAndLikeType(post.getPostId(), LikeType.POST);
+            return new PostResponse(post, likeCounts);
+        });
+    }
+
+    public PostResponse getPost(Long postId) {
+        Post post = findPostById(postId);
+        int countPostLikes = countLikeForPost(postId);
+        return new PostResponse(post, countPostLikes);
+    }
+
+    public Integer countLikeForPost(Long postId) {
+        return likeRepository.countByItemIdAndLikeType(postId, LikeType.POST);
     }
 
     @Transactional
     public void updatePost(Long postId, PostRequest postRequest, Long currentMemberNumber) {
-        Post post = postRepository.findByPostIdAndIsDeletedFalse(postId)
-                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+        Post post = findPostById(postId);
 
         checkAuthorizedMember(currentMemberNumber, post);
 
@@ -61,10 +76,14 @@ public class PostService {
         postRepository.save(post);
     }
 
+    private Post findPostById(Long postId) {
+        return postRepository.findByPostIdAndIsDeletedFalse(postId)
+                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+    }
+
     @Transactional
     public void deletePost(Long postId, Long currentMemberNumber) {
-        Post post = postRepository.findByPostIdAndIsDeletedFalse(postId)
-                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+        Post post = findPostById(postId);
 
         checkAuthorizedMember(currentMemberNumber, post);
 


### PR DESCRIPTION
## 요약
- 댓글 및 대댓글, 작성 삭제 기능 구현
- 무한댓글 방지를 위해 depth를 1로 제한(paraentCommentId 유무 여부로 분리)
- 게시글/댓글 한 개에 대한 조회시 좋아요 갯수 세기

## 상세 작업 내용

- [x] 댓글 기능
- [x] 대댓글 기능(depth 1)
- [x] 댓글 좋아요 기능
- [x] 게시글 조회 시 좋아요 계산
- [x] 댓글 조회 시 좋아요 계산

Closes #10 